### PR TITLE
Add wavy hover link to Papier

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <p>2012–2017<br>Co-founded product design and development consultancy</p>
     </div>
     <div class="item">
-      <p>2017–2021<br>Head of digital product and design at Papier</p>
+      <p>2017–2021<br>Head of digital product and design at <a href="https://papier.com" class="papier-link">Papier</a></p>
     </div>
     <div class="item">
       <p>2021–NOW<br>Instagram creators &amp; emerging platforms design</p>

--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,12 @@ h1 {
     margin-top: 32px;
   }
 }
+
+.papier-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.papier-link:hover {
+  text-decoration-style: wavy;
+}


### PR DESCRIPTION
## Summary
- link the word "Papier" to papier.com
- underline link turns wavy on hover

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686045c3a6a8832fb65a30044c4a7be6