### PR TITLE
Add confetti to history paragraphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@
   </header>
   <div class="history">
     <div class="item">
-      <p>2012–2017<br>Co-founded product design &amp; development agency</p>
+      <p class="history-consultancy">2012–2017<br>Co-founded product design &amp; development agency</p>
     </div>
     <div class="item">
-      <p>2017–2021<br>Head of digital product and design at <a href="https://papier.com" class="papier-link">Papier</a></p>
+      <p class="history-papier">2017–2021<br>Head of digital product and design at <a href="https://papier.com" class="papier-link">Papier</a></p>
     </div>
     <div class="item">
-      <p>2021–NOW<br>Instagram creators &amp; emerging platforms design</p>
+      <p class="history-instagram">2021–NOW<br>Instagram creators &amp; emerging platforms design</p>
     </div>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,59 +1,73 @@
 document.addEventListener('DOMContentLoaded', function () {
-  const papier = document.querySelector('.papier-link');
-  if (!papier) return;
+  const papierParagraph = document.querySelector('.history-papier');
+  const instagramParagraph = document.querySelector('.history-instagram');
+  const consultancyParagraph = document.querySelector('.history-consultancy');
 
-  let mouseX = 0;
-  let mouseY = 0;
-  let timeoutId = null;
+  const setupConfetti = (target, emoji) => {
+    if (!target) return;
 
-  const randomDelay = () => 300 + Math.random() * 300; // 300ms to 600ms
+    let mouseX = 0;
+    let mouseY = 0;
+    let timeoutId = null;
 
-  const createParticle = () => {
-    const startX = mouseX;
-    const startY = mouseY;
-    const span = document.createElement('span');
-    span.className = 'emoji-confetti';
-    span.textContent = '📕';
-    span.style.left = startX + 'px';
-    span.style.top = startY + 'px';
-    const rotate = Math.random() * 60 - 30; // random rotation between -30 and 30
-    span.style.transform = `translate(-50%, -50%) rotate(${rotate}deg) scale(1)`;
-    document.body.appendChild(span);
+    const randomDelay = () => 300 + Math.random() * 300; // 300ms to 600ms
 
+    const createParticle = () => {
+      const startX = mouseX;
+      const startY = mouseY;
+      const span = document.createElement('span');
+      span.className = 'emoji-confetti';
+      span.textContent = emoji;
+      span.style.left = startX + 'px';
+      span.style.top = startY + 'px';
+      const rotate = Math.random() * 60 - 30; // random rotation between -30 and 30
+      span.style.transform = `translate(-50%, -50%) rotate(${rotate}deg) scale(0.3)`;
+      span.style.transition = 'transform 0.2s ease-out';
+      document.body.appendChild(span);
 
-    const dx = (Math.random() - 0.5) * 20; // random horizontal shift
+      const dx = (Math.random() - 0.5) * 20; // random horizontal shift
 
-    requestAnimationFrame(() => {
-      span.style.opacity = '0';
-      span.style.top = (startY - 50) + 'px';
-      span.style.left = (startX + dx) + 'px';
-      span.style.transform = `translate(-50%, -50%) rotate(${rotate}deg) scale(0.5)`;
+      requestAnimationFrame(() => {
+        span.style.transform = `translate(-50%, -50%) rotate(${rotate}deg) scale(1)`;
+      });
+
+      setTimeout(() => {
+        span.style.transition = 'top 1s ease-out, left 1s ease-out, transform 1s ease-out, opacity 1s ease-out';
+        span.style.opacity = '0';
+        span.style.top = (startY - 50) + 'px';
+        span.style.left = (startX + dx) + 'px';
+        span.style.transform = `translate(-50%, -50%) rotate(${rotate}deg) scale(0.5)`;
+      }, 200);
+
+      setTimeout(() => span.remove(), 1200);
+    };
+
+    const scheduleParticle = () => {
+      timeoutId = setTimeout(() => {
+        createParticle();
+        scheduleParticle();
+      }, randomDelay());
+    };
+
+    target.addEventListener('mousemove', (e) => {
+      mouseX = e.clientX;
+      mouseY = e.clientY;
     });
 
-    setTimeout(() => span.remove(), 1000);
-  };
-
-  const scheduleParticle = () => {
-    timeoutId = setTimeout(() => {
+    target.addEventListener('mouseenter', (e) => {
+      mouseX = e.clientX;
+      mouseY = e.clientY;
       createParticle();
       scheduleParticle();
-    }, randomDelay());
+    });
+
+    target.addEventListener('mouseleave', () => {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    });
   };
 
-  papier.addEventListener('mousemove', (e) => {
-    mouseX = e.clientX;
-    mouseY = e.clientY;
-  });
-
-  papier.addEventListener('mouseenter', (e) => {
-    mouseX = e.clientX;
-    mouseY = e.clientY;
-    createParticle();
-    scheduleParticle();
-  });
-
-  papier.addEventListener('mouseleave', () => {
-    clearTimeout(timeoutId);
-    timeoutId = null;
-  });
+  setupConfetti(papierParagraph, '📕');
+  setupConfetti(instagramParagraph, '📷');
+  setupConfetti(consultancyParagraph, '👨‍💻');
 });


### PR DESCRIPTION
## Summary
- add `history-` classes to each history paragraph
- refactor `script.js` to use a reusable confetti setup
- update animation so emojis grow from 0.3 to 1 then shrink to 0.5
- extend confetti to consultancy and Instagram paragraphs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68608c93c464832f805388df70dc100c