### PR TITLE
Add clickable webfont toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
   const isTouchDevice =
     'ontouchstart' in window || navigator.maxTouchPoints > 0;
+
+  document.body.addEventListener('click', () => {
+    document.body.classList.toggle('sauce-font');
+  });
+
   if (isTouchDevice) {
     return; // disable confetti on touch screens
   }

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,10 @@
+@font-face {
+  font-family: 'sauce_tm';
+  src: url('sauce_tm-webfont.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
 body {
   background: #1D2121;
   color: #E7DBC5;
@@ -17,6 +24,10 @@ h1 {
   font-weight: 600;
   line-height: 1;
   margin: 0;
+}
+
+body.sauce-font h1 {
+  font-family: 'sauce_tm', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 .intro {


### PR DESCRIPTION
## Summary
- add `sauce_tm` webfont with `@font-face`
- toggle H1 font on click by adding `sauce-font` class

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`
- `cargo test` *(fails: could not find Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_6861f6aa4eb4832f87209b11cd27d059