### PR TITLE
Add stylistic set support for Sauce TM OTF

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'sauce_tm';
-  src: url('sauce_tm-webfont.woff2') format('woff2');
+  src: url('Sauce TM.otf') format('opentype'),
+       url('sauce_tm-webfont.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
 }
@@ -28,6 +29,7 @@ h1 {
 
 body.sauce-font h1 {
   font-family: 'sauce_tm', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-feature-settings: "ss02";
   font-size: 16vw;
   line-height: 80%;
   font-weight: 300;


### PR DESCRIPTION
## Summary
- include the OTF font with woff2 fallback
- enable the second stylistic set when the Sauce TM font is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861fb644f08832f9ab95025a7a0beba